### PR TITLE
Updated assembly_annotation pipeline clean stats

### DIFF
--- a/bu_isciii/templates/services.json
+++ b/bu_isciii/templates/services.json
@@ -8,7 +8,7 @@
         "end": "",
         "description": "Nextflow assembly pipeline to assemble bacterial genomes",
         "clean": {
-          "folders":["03-assembly/trimming/trimmed", "01-preprocessing", "work"],
+          "folders":["work"],
           "files":[""]
         },
         "no_copy": ["RAW", "TMP", "latest"],


### PR DESCRIPTION
The assembly_annotation pipeline no longer requires any deletion further than the work directory, as trimmed reads are only included in results if specifically stated by the user. All results left in the directory are (somewhat) relevant.

No files were deemed useless or not important enough to be included in the category.